### PR TITLE
fix: keep inferring n_elements

### DIFF
--- a/crabnet/model.py
+++ b/crabnet/model.py
@@ -72,10 +72,6 @@ class Model():
         print(f'loading data with up to {data_loaders.n_elements:0.0f} '
               f'elements in the formula')
 
-        # update n_elements after loading dataset
-        if self.n_elements != 'infer':
-            self.n_elements = data_loaders.n_elements
-
         data_loader = data_loaders.get_data_loaders(inference=inference)
         y = data_loader.dataset.data[1]
         if train:

--- a/crabnet/model.py
+++ b/crabnet/model.py
@@ -73,7 +73,8 @@ class Model():
               f'elements in the formula')
 
         # update n_elements after loading dataset
-        self.n_elements = data_loaders.n_elements
+        if self.n_elements != 'infer':
+            self.n_elements = data_loaders.n_elements
 
         data_loader = data_loaders.get_data_loaders(inference=inference)
         y = data_loader.dataset.data[1]


### PR DESCRIPTION
When n_elements was set to 'infer', the first call to `load_data` would overwrite the value of `n_elements` to a concrete integer, fixing the number of elements for all subsequent calls.